### PR TITLE
add BLE2902

### DIFF
--- a/src/Ble_esp32.h
+++ b/src/Ble_esp32.h
@@ -202,6 +202,9 @@ bool BleMidiInterface::begin(const char* deviceName)
                                                      BLECharacteristic::PROPERTY_NOTIFY |
                                                      BLECharacteristic::PROPERTY_WRITE_NR
                                                      );
+    // Add CCCD 0x2902 to allow notify
+    _characteristic->addDescriptor(new BLE2902());
+
     _characteristic->setCallbacks(new MyCharacteristicCallbacks(this));
     // Start the service
     service->start();


### PR DESCRIPTION
Hi,

I added ```_characteristic->addDescriptor(new BLE2902());``` into the ```Ble_esp32.h``` to accept notify registration at the client.
This change makes it possible to connect with Mac or Windows as a BLE-MIDI device.

Thanks