### PR TITLE
Update Ble_esp32.h

### DIFF
--- a/src/Ble_esp32.h
+++ b/src/Ble_esp32.h
@@ -4,6 +4,7 @@
 #include <BLEDevice.h>
 #include <BLEUtils.h>
 #include <BLEServer.h>
+#include <BLE2902.h>
 
 #include "utility/AbstractMidiInterface.h"
 using namespace Midi;


### PR DESCRIPTION
#include <BLE2902.h> in order to use library with PlatformIO