### PR TITLE
Add mbed_nano to list of compatible architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=BLE-MIDI I/Os for Arduino
 paragraph=MIDI over Bluetooth Low Energy (BLE-MIDI) 1.0 for Arduino
 category=Communication
 url=https://github.com/lathoub/Arduino-BLE-MIDI
-architectures=esp32,samd,megaavr,mbed,nrf52
+architectures=esp32,samd,megaavr,mbed,mbed_nano,nrf52
 includes=BLEMIDI_Transport.h
 depends=MIDI Library, NimBLE-Arduino, ArduinoBLE


### PR DESCRIPTION
In the 2.0.0 release of the Arduino Mbed OS Boards platform, the mbed architecture split into four architectures:
- mbed_edge: Arduino Edge Control
- mbed_nano: Nano 33 BLE and Nano RP2040 Connect
- mbed_rp2040: Raspberry Pi Pico
- mbed_portenta: Portenta H7

The mbed architecture should be retained for backwards support, but the new mbed_nano should also be added to avoid spurious incompatibility warnings and the library's examples being shown under the File > Examples > INCOMPATIBLE menu of the Arduino IDE when the Nano 33 BLE board is selected.