### PR TITLE
Parser Upgraded

### DIFF
--- a/src/BLEMIDI_Transport.h
+++ b/src/BLEMIDI_Transport.h
@@ -10,8 +10,6 @@
 #include "BLEMIDI_Defs.h"
 #include "BLEMIDI_Namespace.h"
 
-// #define CHECK_BIT(var, pos) (!!((var) & (1 << (pos))))
-
 BEGIN_BLEMIDI_NAMESPACE
 
 template <class T, class _Settings = DefaultSettings>
@@ -49,7 +47,7 @@ public:
     {
         mBleClass.begin(mDeviceName, this);
     }
-
+    
     void end()
     {
         mBleClass.end();
@@ -77,7 +75,7 @@ public:
 
     void endTransmission()
     {
-        if (mTxBuffer[mTxIndex - 1] == MIDI_NAMESPACE::MidiType::SystemExclusiveEnd)
+        if (mTxBuffer[mTxIndex - 1] == 0xF7)
         {
             if (mTxIndex >= sizeof(mTxBuffer))
             {
@@ -90,7 +88,7 @@ public:
             {
                 mTxBuffer[mTxIndex - 1] = mTimestampLow; // or generate new ?
             }
-            mTxBuffer[mTxIndex++] = MIDI_NAMESPACE::MidiType::SystemExclusiveEnd;
+            mTxBuffer[mTxIndex++] = 0xF7;
         }
 
         mBleClass.write(mTxBuffer, mTxIndex);
@@ -110,7 +108,6 @@ public:
             return mRxIndex;
 
         mRxBuffer[mRxIndex++] = byte;
-
         return mRxIndex;
     }
 
@@ -221,6 +218,14 @@ public:
     MIDI messages. In the MIDI BLE protocol, the System Real-Time messages must be deinterleaved
     from other messages – except for System Exclusive messages.
     */
+
+  /**
+   * If #define RUNNING_ENABLE is commented, it will transform all incoming runningStatus messages in full midi messages.
+   * Else, it will put in the buffer the same info that it had received (runningStatus will be not transformated).
+   * It recommend not use runningStatus by default. Only use if parser accepts runningStatus and your application has a so high transmission rate.
+   */ 
+  //#define RUNNING_ENABLE
+
     void receive(byte *buffer, size_t length)
     {
         // Pointers used to search through payload.
@@ -229,108 +234,158 @@ public:
 
         // lastStatus used to capture runningStatus
         byte lastStatus;
+        // previousStatus used to continue a runningStatus interrupted by a timeStamp or a System Message.
+        byte previousStatus = 0x00;
 
         byte headerByte = buffer[lPtr++];
-//        auto signatureIs1 = CHECK_BIT(headerByte, 7 - 1); // must be 1
-//        auto reservedIs0 = !CHECK_BIT(headerByte, 6 - 1); // must be 0
+
         auto timestampHigh = 0x3f & headerByte;
 
         byte timestampByte = buffer[lPtr++];
         uint16_t timestamp = 0;
 
         bool sysExContinuation = false;
+        bool runningStatusContinuation = false;
 
         if (timestampByte >= 80) // if bit 7 is 1, it's a timestampByte
         {
-            timestamp = setMidiTimestamp(headerByte, timestampByte);
+            auto timestampLow = 0x7f & timestampByte;
+            timestamp = timestampLow + (timestampHigh << 7);
         }
         else // if bit 7 is 0, it's the Continuation of a previous SysEx
         {
             sysExContinuation = true;
-            lPtr--;
+            lPtr--; // the second byte is part of the SysEx
         }
 
-        // While statement contains incrementing pointers and breaks when buffer size exceeded.
+        //While statement contains incrementing pointers and breaks when buffer size exceeded.
         while (true)
         {
             lastStatus = buffer[lPtr];
 
-            if ((buffer[lPtr] < 0x80) && !sysExContinuation)
-                return; // Status message not present, bail
+            if (previousStatus == 0x00)
+            {
+                if ((lastStatus < 0x80) && !sysExContinuation)
+                    return; // Status message not present and it is not a runningStatus continuation, bail
+            }
+            else if (lastStatus < 0x80)
+            {
+                lastStatus = previousStatus;
+                runningStatusContinuation = true;
+            }
 
             // Point to next non-data byte
             rPtr = lPtr;
             while ((buffer[rPtr + 1] < 0x80) && (rPtr < (length - 1)))
                 rPtr++;
 
-            // look at l and r pointers and decode by size.
-            if (rPtr - lPtr < 1)
+            if (!runningStatusContinuation)
             {
-                // Time code or system
-                mBleClass.add(lastStatus);
-            }
-            else if (rPtr - lPtr < 2)
-            {
-                mBleClass.add(lastStatus);
-                mBleClass.add(buffer[lPtr + 1]);
-            }
-            else if (rPtr - lPtr < 3)
-            {
-                mBleClass.add(lastStatus);
-                mBleClass.add(buffer[lPtr + 1]);
-                mBleClass.add(buffer[lPtr + 2]);
-            }
-            else
-            {
-
-                auto midiType = buffer[lPtr] & 0xF0;
-                if (sysExContinuation)
-                    midiType = MIDI_NAMESPACE::MidiType::SystemExclusive;
-
-                // Too much data
                 // If not System Common or System Real-Time, send it as running status
+
+                auto midiType = lastStatus & 0xF0;
+                if (sysExContinuation)
+                    midiType = 0xF0;
+
                 switch (midiType)
                 {
-                case MIDI_NAMESPACE::MidiType::NoteOff:
-                case MIDI_NAMESPACE::MidiType::NoteOn:
-                case MIDI_NAMESPACE::MidiType::AfterTouchPoly:
-                case MIDI_NAMESPACE::MidiType::ControlChange:
-                case MIDI_NAMESPACE::MidiType::PitchBend:
+                case 0x80:
+                case 0x90:
+                case 0xA0:
+                case 0xB0:
+                case 0xE0:
+#ifdef RUNNING_ENABLE
+                    mBleClass.add(lastStatus);
+#endif
                     for (auto i = lPtr; i < rPtr; i = i + 2)
                     {
+#ifndef RUNNING_ENABLE
                         mBleClass.add(lastStatus);
+#endif
                         mBleClass.add(buffer[i + 1]);
                         mBleClass.add(buffer[i + 2]);
                     }
                     break;
-                case MIDI_NAMESPACE::MidiType::ProgramChange:
-                case MIDI_NAMESPACE::MidiType::AfterTouchChannel:
+                case 0xC0:
+                case 0xD0:
+#ifdef RUNNING_ENABLE
+                    mBleClass.add(lastStatus);
+#endif
                     for (auto i = lPtr; i < rPtr; i = i + 1)
                     {
+#ifndef RUNNING_ENABLE
                         mBleClass.add(lastStatus);
+#endif
                         mBleClass.add(buffer[i + 1]);
                     }
                     break;
-                case MIDI_NAMESPACE::MidiType::SystemExclusive:
-
-                    mBleClass.add(buffer[lPtr]);
+                case 0xF0:
+                    mBleClass.add(lastStatus);
                     for (auto i = lPtr; i < rPtr; i++)
                         mBleClass.add(buffer[i + 1]);
 
                     break;
+
                 default:
                     break;
                 }
+            }
+            else
+            {
+#ifndef RUNNING_ENABLE
+                auto midiType = lastStatus & 0xF0;
+                if (sysExContinuation)
+                    midiType = 0xF0;
+
+                switch (midiType)
+                {
+                case 0x80:
+                case 0x90:
+                case 0xA0:
+                case 0xB0:
+                case 0xE0:
+                    //3 bytes full Midi -> 2 bytes runningStatus
+                    for (auto i = lPtr; i <= rPtr; i = i + 2)
+                    {
+                        mBleClass.add(lastStatus);
+                        mBleClass.add(buffer[i]);
+                        mBleClass.add(buffer[i + 1]);
+                    }
+                    break;
+                case 0xC0:
+                case 0xD0:
+                    //2 bytes full Midi -> 1 byte runningStatus
+                    for (auto i = lPtr; i <= rPtr; i = i + 1)
+                    {
+                        mBleClass.add(lastStatus);
+                        mBleClass.add(buffer[i]);
+                    }
+                    break;
+
+                default:
+                    break;
+                }
+#else
+                mBleClass.add(lastStatus);
+                for (auto i = lPtr; i <= rPtr; i++)
+                    mBleClass.add(buffer[i]);
+#endif
+                runningStatusContinuation = false;
             }
 
             if (++rPtr >= length)
                 return; // end of packet
 
+            if (lastStatus < 0xf0) //exclude System Message. They must not be RunningStatus
+            {
+                previousStatus = lastStatus;
+            }
+
             timestampByte = buffer[rPtr++];
             if (timestampByte >= 80) // is bit 7 set?
             {
-                timestamp = setMidiTimestamp(headerByte, timestampByte); 
-                // what do to with the timestamp?
+                auto timestampLow = 0x7f & timestampByte;
+                timestamp = timestampLow + (timestampHigh << 7);
             }
 
             // Point to next status

--- a/src/BLEMIDI_Transport.h
+++ b/src/BLEMIDI_Transport.h
@@ -12,6 +12,10 @@
 
 BEGIN_BLEMIDI_NAMESPACE
 
+using namespace MIDI_NAMESPACE;
+
+#define MIDI_TYPE 0x80
+
 template <class T, class _Settings = DefaultSettings>
 class BLEMIDI_Transport
 {
@@ -47,7 +51,7 @@ public:
     {
         mBleClass.begin(mDeviceName, this);
     }
-    
+
     void end()
     {
         mBleClass.end();
@@ -75,7 +79,7 @@ public:
 
     void endTransmission()
     {
-        if (mTxBuffer[mTxIndex - 1] == 0xF7)
+        if (mTxBuffer[mTxIndex - 1] == SystemExclusiveEnd)
         {
             if (mTxIndex >= sizeof(mTxBuffer))
             {
@@ -88,7 +92,7 @@ public:
             {
                 mTxBuffer[mTxIndex - 1] = mTimestampLow; // or generate new ?
             }
-            mTxBuffer[mTxIndex++] = 0xF7;
+            mTxBuffer[mTxIndex++] = SystemExclusiveEnd;
         }
 
         mBleClass.write(mTxBuffer, mTxIndex);
@@ -219,12 +223,12 @@ public:
     from other messages – except for System Exclusive messages.
     */
 
-  /**
+    /**
    * If #define RUNNING_ENABLE is commented, it will transform all incoming runningStatus messages in full midi messages.
    * Else, it will put in the buffer the same info that it had received (runningStatus will be not transformated).
    * It recommend not use runningStatus by default. Only use if parser accepts runningStatus and your application has a so high transmission rate.
-   */ 
-  //#define RUNNING_ENABLE
+   */
+    //#define RUNNING_ENABLE
 
     void receive(byte *buffer, size_t length)
     {
@@ -235,7 +239,7 @@ public:
         // lastStatus used to capture runningStatus
         byte lastStatus;
         // previousStatus used to continue a runningStatus interrupted by a timeStamp or a System Message.
-        byte previousStatus = 0x00;
+        byte previousStatus = InvalidType;
 
         byte headerByte = buffer[lPtr++];
 
@@ -247,10 +251,10 @@ public:
         bool sysExContinuation = false;
         bool runningStatusContinuation = false;
 
-        if (timestampByte >= 80) // if bit 7 is 1, it's a timestampByte
+        if (timestampByte >= MIDI_TYPE) // if bit 7 is 1, it's a timestampByte
         {
-            auto timestampLow = 0x7f & timestampByte;
-            timestamp = timestampLow + (timestampHigh << 7);
+            timestamp = setMidiTimestamp(headerByte, timestampByte);
+            // what do to with the timestamp?
         }
         else // if bit 7 is 0, it's the Continuation of a previous SysEx
         {
@@ -263,12 +267,12 @@ public:
         {
             lastStatus = buffer[lPtr];
 
-            if (previousStatus == 0x00)
+            if (previousStatus == InvalidType)
             {
-                if ((lastStatus < 0x80) && !sysExContinuation)
+                if ((lastStatus < MIDI_TYPE) && !sysExContinuation)
                     return; // Status message not present and it is not a runningStatus continuation, bail
             }
-            else if (lastStatus < 0x80)
+            else if (lastStatus < MIDI_TYPE)
             {
                 lastStatus = previousStatus;
                 runningStatusContinuation = true;
@@ -276,7 +280,7 @@ public:
 
             // Point to next non-data byte
             rPtr = lPtr;
-            while ((buffer[rPtr + 1] < 0x80) && (rPtr < (length - 1)))
+            while ((buffer[rPtr + 1] < MIDI_TYPE) && (rPtr < (length - 1)))
                 rPtr++;
 
             if (!runningStatusContinuation)
@@ -285,15 +289,15 @@ public:
 
                 auto midiType = lastStatus & 0xF0;
                 if (sysExContinuation)
-                    midiType = 0xF0;
+                    midiType = SystemExclusive;
 
                 switch (midiType)
                 {
-                case 0x80:
-                case 0x90:
-                case 0xA0:
-                case 0xB0:
-                case 0xE0:
+                case NoteOff:
+                case NoteOn:
+                case AfterTouchPoly:
+                case ControlChange:
+                case PitchBend:
 #ifdef RUNNING_ENABLE
                     mBleClass.add(lastStatus);
 #endif
@@ -306,8 +310,8 @@ public:
                         mBleClass.add(buffer[i + 2]);
                     }
                     break;
-                case 0xC0:
-                case 0xD0:
+                case ProgramChange:
+                case AfterTouchChannel:
 #ifdef RUNNING_ENABLE
                     mBleClass.add(lastStatus);
 #endif
@@ -319,7 +323,7 @@ public:
                         mBleClass.add(buffer[i + 1]);
                     }
                     break;
-                case 0xF0:
+                case SystemExclusive:
                     mBleClass.add(lastStatus);
                     for (auto i = lPtr; i < rPtr; i++)
                         mBleClass.add(buffer[i + 1]);
@@ -335,15 +339,15 @@ public:
 #ifndef RUNNING_ENABLE
                 auto midiType = lastStatus & 0xF0;
                 if (sysExContinuation)
-                    midiType = 0xF0;
+                    midiType = SystemExclusive;
 
                 switch (midiType)
                 {
-                case 0x80:
-                case 0x90:
-                case 0xA0:
-                case 0xB0:
-                case 0xE0:
+                case NoteOff:
+                case NoteOn:
+                case AfterTouchPoly:
+                case ControlChange:
+                case PitchBend:
                     //3 bytes full Midi -> 2 bytes runningStatus
                     for (auto i = lPtr; i <= rPtr; i = i + 2)
                     {
@@ -352,8 +356,8 @@ public:
                         mBleClass.add(buffer[i + 1]);
                     }
                     break;
-                case 0xC0:
-                case 0xD0:
+                case ProgramChange:
+                case AfterTouchChannel:
                     //2 bytes full Midi -> 1 byte runningStatus
                     for (auto i = lPtr; i <= rPtr; i = i + 1)
                     {
@@ -376,16 +380,16 @@ public:
             if (++rPtr >= length)
                 return; // end of packet
 
-            if (lastStatus < 0xf0) //exclude System Message. They must not be RunningStatus
+            if (lastStatus < SystemExclusive) //exclude System Message. They must not be RunningStatus
             {
                 previousStatus = lastStatus;
             }
 
             timestampByte = buffer[rPtr++];
-            if (timestampByte >= 80) // is bit 7 set?
+            if (timestampByte >= MIDI_TYPE) // is bit 7 set?
             {
-                auto timestampLow = 0x7f & timestampByte;
-                timestamp = timestampLow + (timestampHigh << 7);
+                timestamp = setMidiTimestamp(headerByte, timestampByte);
+                // what do to with the timestamp?
             }
 
             // Point to next status


### PR DESCRIPTION
TEST 

SETUP:
```
    MIDI2.setHandleError([](int8_t fptr)
                         {
                           Serial.println("\n\nError in parser:" + String(fptr) + "\n\r\n");
                           //delay(1000);
                         });

    MIDI2.setHandleMessage([](const midi::Message<128U> &msg)
                           {
                             Serial.println("\n### Parser ###");
                             Serial.print("Type: ");
                             Serial.print((msg.type), HEX);
                             Serial.println();
                             Serial.println("Lenght: " + String(msg.length));
                             Serial.println("Channel: " + String(msg.channel));
                             if (msg.type == 0xF0)
                             {
                               for (auto i = 0; i < msg.getSysExSize(); i++)
                               {
                                 Serial.print((msg.sysexArray[i]), HEX);
                                 Serial.print(" ");
                               }
                               Serial.println();
                             }
                             else
                             {
                               Serial.print(msg.type + msg.channel - 1, HEX);
                               Serial.print(" ");
                               Serial.print((msg.data1), HEX);
                               Serial.print(" ");
                               Serial.println((msg.data2), HEX);
                             }
                           });

xTaskCreatePinnedToCore([](){
                           for(;;){
                           MIDI2.read();
                           vTaskDelay(1 / portTICK_PERIOD_MS);
                           }
                           },
                          "MIDI-READ",
                          3000,
                          NULL,
                          1,
                          NULL,
                          1);
```

TEST: (the same like for MSVS)

```
Serial.println("SETUP OK");

  Serial.println();
  Serial.println("SysEx with RealTime msg in the middle --------");
  byte sysExAndRealTime[] = {0xB0, 0xF4,             // header + timestamp
                             0xF0,                   // start SysEx
                             0x01, 0x02, 0x03, 0x04, // SysEx data
                             // RealTime message in the middle of a SysEx
                             0xF3,                   // timestampLow
                             0xFA,                   // Realtime msg: Start
                             0x05, 0x06, 0x07, 0x08, // rest of sysex data
                             0xF4,                   // timestampLow
                             0xF7};                  // end of SysEx
  BLEMIDI2.receive(sysExAndRealTime, sizeof(sysExAndRealTime));
  MIDI2.read();
  delay(1000);
  Serial.println();

  Serial.println("SysEx ---------");

  byte sysExPart[] = {0xB0, 0xF4,                                     // header + timestamp
                      0xF0,                                           // start SysEx
                      0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // sysex data
                      0xF4,                                           // timestampLow
                      0xF7};                                          // end of SysEx
  BLEMIDI2.receive(sysExPart, sizeof(sysExPart));
  MIDI2.read();
  delay(1000);
  Serial.println();

  Serial.println("SysEx part 1");
  byte sysExPart1[] = {0xB0, 0xF4,                                      // header + timestamp
                       0xF0,                                            // start SysEx
                       0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}; // sysex data
  BLEMIDI2.receive(sysExPart1, sizeof(sysExPart1));
  MIDI2.read();
  delay(1000);
  Serial.println();

  Serial.println("SysEx part 2");
  byte sysExPart2[] = {0xB0,                                     // 1 byte header
                       0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, // sysex data (cont)
                       0xF4,                                     // timestampLow
                       0xF7};                                    // end of SysEx
  BLEMIDI2.receive(sysExPart2, sizeof(sysExPart2));
  MIDI2.read();
  delay(1000);
  Serial.println();

  Serial.println("ble Packet with 1 MIDI messages");
  byte blePacketWithOneMIDIMessage[] = {0xA8, 0xC0,
                                        0x90, 0x3E, 0x3E};
  BLEMIDI2.receive(blePacketWithOneMIDIMessage, sizeof(blePacketWithOneMIDIMessage));
  MIDI2.read();
  delay(1000);
  Serial.println();

  Serial.println("ble Packet with 2 MIDI messages");
  byte blePacketWithTwoMIDIMessage[] = {0xA8, 0xC0,
                                        0x90, 0x3E, 0x3E,
                                        0xC1,
                                        0x91, 0x3E, 0x3E};
  BLEMIDI2.receive(blePacketWithTwoMIDIMessage, sizeof(blePacketWithTwoMIDIMessage));
  MIDI2.read();
  delay(1000);
  Serial.println();

  Serial.println("ble Packet with 3 MIDI messages");
  byte blePacketWithThreeMIDIMessage[] = {0xA8, 0xC0,
                                          0x90, 0x3E, 0x3E,
                                          0xC1,
                                          0xF0,
                                          0x01, 0x02,
                                          0xC2,
                                          0xF7,
                                          0xC3,
                                          0x91, 0x3E, 0x3E};
  BLEMIDI2.receive(blePacketWithThreeMIDIMessage, sizeof(blePacketWithThreeMIDIMessage));
  MIDI2.read();
  delay(1000);
  Serial.println();

  Serial.println("2 MIDI messages with multiple running status");

  byte twoMIDIMessageWithRunningStatus[] = {0xA9, 0xAD,
                                            0xD1, 0x74, //Full Midi 2 bytes(afterTouch)
                                            0x73,       //running
                                            0xAE,       //timeStamp
                                            0x72,       //running after timeStamp
                                            0xAF,       //timeStamp
                                            0x71,       //running after timeStamp
                                            0x70,
                                            0x69,
                                            0x68,
                                            0xB2,             //
                                            0x92, 0x36, 0x70, //Full Midi 3 bytes (noteOn)
                                            0xB3,             //
                                            0x93, 0x37, 0x71,
                                            0x38, 0x72,
                                            0x39, 0x73,
                                            0xB4, //
                                            0x40, 0x74};
  BLEMIDI2.receive(twoMIDIMessageWithRunningStatus, sizeof(twoMIDIMessageWithRunningStatus));
  MIDI2.read();
  delay(1000);
  Serial.println();
  Serial.println("END TEST");

  while (1)
  {
  };
```

RESAULTS RUNNIGSTATUS ENABLE

```
SETUP OK

SysEx with RealTime msg in the middle --------

### Parser ###
Type: FA
Lenght: 1
Channel: 0
F9 0 0

### Parser ###
Type: F0
Lenght: 10
Channel: 0
F0 1 2 3 4 5 6 7 8 F7

SysEx ---------

### Parser ###
Type: F0
Lenght: 10
Channel: 0
F0 1 2 3 4 5 6 7 8 F7

SysEx part 1

SysEx part 2

### Parser ###
Type: F0
Lenght: 17
Channel: 0
F0 1 2 3 4 5 6 7 8 9 A B C D E F F7

ble Packet with 1 MIDI messages

### Parser ###
Type: 90
Lenght: 17
Channel: 1
90 3E 3E

ble Packet with 2 MIDI messages

### Parser ###
Type: 90
Lenght: 17
Channel: 1
90 3E 3E

### Parser ###
Type: 90
Lenght: 17
Channel: 2
91 3E 3E

ble Packet with 3 MIDI messages

### Parser ###
Type: 90
Lenght: 17
Channel: 1
90 3E 3E

### Parser ###
Type: F0
Lenght: 4
Channel: 0
F0 1 2 F7

### Parser ###
Type: 90
Lenght: 4
Channel: 2
91 3E 3E

2 MIDI messages with multiple running status

### Parser ###
Type: D0
Lenght: 4
Channel: 2
D1 74 0

### Parser ###
Type: D0
Lenght: 1
Channel: 2
D1 73 0

### Parser ###
Type: D0
Lenght: 1
Channel: 2
D1 72 0

### Parser ###
Type: D0
Lenght: 1
Channel: 2
D1 71 0

### Parser ###
Type: D0
Lenght: 1
Channel: 2
D1 70 0

### Parser ###
Type: D0
Lenght: 1
Channel: 2
D1 69 0

### Parser ###
Type: D0
Lenght: 1
Channel: 2
D1 68 0

### Parser ###
Type: 90
Lenght: 1
Channel: 3
92 36 70

### Parser ###
Type: 90
Lenght: 1
Channel: 4
93 37 71

### Parser ###
Type: 90
Lenght: 1
Channel: 4
93 38 72

### Parser ###
Type: 90
Lenght: 1
Channel: 4
93 39 73

### Parser ###
Type: 90
Lenght: 1
Channel: 4
93 40 74

END TEST
```

RESAULTS RUNNIGSTATUS DISABLE

```
SETUP OK

SysEx with RealTime msg in the middle --------

### Parser ###
Type: FA
Lenght: 1
Channel: 0
F9 0 0

### Parser ###
Type: F0
Lenght: 10
Channel: 0
F0 1 2 3 4 5 6 7 8 F7

SysEx ---------

### Parser ###
Type: F0
Lenght: 10
Channel: 0
F0 1 2 3 4 5 6 7 8 F7

SysEx part 1

SysEx part 2

### Parser ###
Type: F0
Lenght: 17
Channel: 0
F0 1 2 3 4 5 6 7 8 9 A B C D E F F7

ble Packet with 1 MIDI messages

### Parser ###
Type: 90
Lenght: 17
Channel: 1
90 3E 3E

ble Packet with 2 MIDI messages

### Parser ###
Type: 90
Lenght: 17
Channel: 1
90 3E 3E

### Parser ###
Type: 90
Lenght: 17
Channel: 2
91 3E 3E

ble Packet with 3 MIDI messages

### Parser ###
Type: 90
Lenght: 17
Channel: 1
90 3E 3E

### Parser ###
Type: F0
Lenght: 4
Channel: 0
F0 1 2 F7

### Parser ###
Type: 90
Lenght: 4
Channel: 2
91 3E 3E

2 MIDI messages with multiple running status

### Parser ###
Type: D0
Lenght: 4
Channel: 2
D1 74 0

### Parser ###
Type: D0
Lenght: 4
Channel: 2
D1 73 0

### Parser ###
Type: D0
Lenght: 4
Channel: 2
D1 72 0

### Parser ###
Type: D0
Lenght: 4
Channel: 2
D1 71 0

### Parser ###
Type: D0
Lenght: 4
Channel: 2
D1 70 0

### Parser ###
Type: D0
Lenght: 4
Channel: 2
D1 69 0

### Parser ###
Type: D0
Lenght: 4
Channel: 2
D1 68 0

### Parser ###
Type: 90
Lenght: 4
Channel: 3
92 36 70

### Parser ###
Type: 90
Lenght: 4
Channel: 4
93 37 71

### Parser ###
Type: 90
Lenght: 4
Channel: 4
93 38 72

### Parser ###
Type: 90
Lenght: 4
Channel: 4
93 39 73

### Parser ###
Type: 90
Lenght: 4
Channel: 4
93 40 74

END TEST
```
You can compare with https://comparetext.com/index.html

It only changes the lenght of non-0xF0 messages (not used).