### PR TITLE
Improve transmissions in client mode

### DIFF
--- a/src/hardware/BLEMIDI_Client_ESP32.h
+++ b/src/hardware/BLEMIDI_Client_ESP32.h
@@ -38,6 +38,24 @@
 #endif //Not modify
 
 /*
+###### TX POWER #####
+*/
+/**
+ * Set power transmision
+ *
+ * ESP_PWR_LVL_N12                // Corresponding to -12dbm    Minimum
+ * ESP_PWR_LVL_N9                 // Corresponding to  -9dbm
+ * ESP_PWR_LVL_N6                 // Corresponding to  -6dbm
+ * ESP_PWR_LVL_N3                 // Corresponding to  -3dbm
+ * ESP_PWR_LVL_N0                 // Corresponding to   0dbm
+ * ESP_PWR_LVL_P3                 // Corresponding to  +3dbm
+ * ESP_PWR_LVL_P6                 // Corresponding to  +6dbm
+ * ESP_PWR_LVL_P9                 // Corresponding to  +9dbm    Maximum
+*/
+
+#define BLEMIDI_TX_PWR ESP_PWR_LVL_P9
+
+/*
 ###### SECURITY #####
 */
 
@@ -394,7 +412,7 @@ bool BLEMIDI_Client_ESP32::begin(const char *deviceName, BLEMIDI_Transport<class
     NimBLEDevice::setSecurityAuth(BLEMIDI_CLIENT_SECURITY_AUTH);
 
     /** Optional: set the transmit power, default is 3db */
-    NimBLEDevice::setPower(ESP_PWR_LVL_P9); /** +9db */
+    NimBLEDevice::setPower(BLEMIDI_TX_PWR); /** +9db */
 
     myAdvCB.enableConnection = true;
     scan();

--- a/src/hardware/BLEMIDI_Client_ESP32.h
+++ b/src/hardware/BLEMIDI_Client_ESP32.h
@@ -112,10 +112,10 @@ static uint32_t userOnPassKeyRequest()
          *  0 latency (Number of intervals allowed to skip),
          *  TimeOut (unit: 10ms) 51 * 10ms = 510ms. Timeout should be minimum 100ms.
          */
-#define BLEMIDI_CLIENT_COMM_MIN_INTERVAL    6   // 7.5ms
-#define BLEMIDI_CLIENT_COMM_MAX_INTERVAL    35  // 40ms
-#define BLEMIDI_CLIENT_COMM_LATENCY         0   //
-#define BLEMIDI_CLIENT_COMM_TIMEOUT         200 //2000ms
+#define BLEMIDI_CLIENT_COMM_MIN_INTERVAL 6  // 7.5ms
+#define BLEMIDI_CLIENT_COMM_MAX_INTERVAL 35 // 40ms
+#define BLEMIDI_CLIENT_COMM_LATENCY 0       //
+#define BLEMIDI_CLIENT_COMM_TIMEOUT 200     //2000ms
 
 /*
 #############################################
@@ -322,7 +322,7 @@ protected:
     void onConnect(BLEClient *pClient)
     {
         //Serial.println("##Connected##");
-        pClient->updateConnParams(BLEMIDI_CLIENT_COMM_MIN_INTERVAL, BLEMIDI_CLIENT_COMM_MAX_INTERVAL, BLEMIDI_CLIENT_COMM_LATENCY, BLEMIDI_CLIENT_COMM_TIMEOUT);
+        //pClient->updateConnParams(BLEMIDI_CLIENT_COMM_MIN_INTERVAL, BLEMIDI_CLIENT_COMM_MAX_INTERVAL, BLEMIDI_CLIENT_COMM_LATENCY, BLEMIDI_CLIENT_COMM_TIMEOUT);
         vTaskDelay(1);
         if (_bluetoothEsp32)
         {
@@ -358,10 +358,11 @@ protected:
         { /** Number of intervals allowed to skip */
             return false;
         }
-        else if (params->supervision_timeout > BLEMIDI_CLIENT_COMM_TIMEOUT + 10)
+        else if (params->supervision_timeout > BLEMIDI_CLIENT_COMM_TIMEOUT)
         { /** 10ms units */
             return false;
         }
+        pClient->updateConnParams(params->itvl_min, params->itvl_max, params->latency, params->supervision_timeout);
 
         return true;
     };


### PR DESCRIPTION
Hi again @lathoub.

I have updated client mode.
Client get improved transmission speed because it not needs send data in Write mode now. Now It sends data in WriteNoResponse, that it is faster and allow Real Time playing without latency. Only the first message is sended like Write (with response) because some devices need this first message for clean security flags.
I added a TX power option, that it allows to choose transmit with more power for long distances or safe battery for portable devices.
At last, Client get update communication parameters on request callback propertily.