### PR TITLE
fix panic'ed bug when call BLEMIDI_Client_ESP32::end() is called

### DIFF
--- a/src/hardware/BLEMIDI_Client_ESP32.h
+++ b/src/hardware/BLEMIDI_Client_ESP32.h
@@ -256,7 +256,7 @@ public:
         _client->disconnect();
         _client = nullptr;
 
-        return !_client->isConnected();
+        return true;
     }
 
     void write(uint8_t *data, uint8_t length)


### PR DESCRIPTION
Hi, 

Calling isConnected() after assigning nullptr. So when manually disconnect client from server calling BLEMIDI_Client_ESP32::end(), it is caused panic. 