### PR TITLE
Callback method added that returns the name of the connected BLE-MIDI device

### DIFF
--- a/src/BLEMIDI_Transport.h
+++ b/src/BLEMIDI_Transport.h
@@ -185,6 +185,7 @@ protected:
 public:
     // callbacks
     void (*_connectedCallback)() = nullptr;
+    void (*_connectedCallbackDeviceName)(char *) = nullptr;
     void (*_disconnectedCallback)() = nullptr;
 
     BLEMIDI_Transport &setName(const char *deviceName)
@@ -197,6 +198,12 @@ public:
     BLEMIDI_Transport &setHandleConnected(void (*fptr)())
     {
         _connectedCallback = fptr;
+        return *this;
+    }
+    
+    BLEMIDI_Transport &setHandleConnected(void (*fptr)(char*))
+    {
+        _connectedCallbackDeviceName= fptr;
         return *this;
     }
 

--- a/src/hardware/BLEMIDI_Client_ESP32.h
+++ b/src/hardware/BLEMIDI_Client_ESP32.h
@@ -228,7 +228,8 @@ private:
     BLERemoteCharacteristic *_characteristic = nullptr;
     BLERemoteService *pSvc = nullptr;
     bool firstTimeSend = true; //First writeValue get sends like Write with reponse for clean security flags. After first time, all messages are send like WriteNoResponse for increase transmision speed.
-
+    char connectedDeviceName[24];
+    
     BLEMIDI_Transport<class BLEMIDI_Client_ESP32> *_bleMidiTransport = nullptr;
 
     bool specificTarget = false;
@@ -303,6 +304,12 @@ protected:
             _bleMidiTransport->_connectedCallback();
         }
         firstTimeSend = true;
+        
+        if (_bleMidiTransport->_connectedCallbackDeviceName)
+        {
+            sprintf(connectedDeviceName, "%s", myAdvCB.advDevice.getName().c_str());
+            _bleMidiTransport->_connectedCallbackDeviceName(connectedDeviceName);
+        }
     }
 
     void disconnected()


### PR DESCRIPTION
This pull request implements a new callback method for passing the device name of the connected BLE-MIDI device as a parameter to the BLE-MIDI client code. It helps to implement different client code functionality dependent on the name of the connected device.
This change shouldn't affect backward compatibility as it implements a new callback method with this functionality.